### PR TITLE
add app launcher tab

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ find_package(Protobuf REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(rtaudio REQUIRED)
 find_package(taglib REQUIRED)
+find_package(X11 REQUIRED)
 
 if(RPI_BUILD)
     add_definitions(-DUSE_OMX -DOMX_SKIP64BIT)
@@ -66,6 +67,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}
                     ${BCM_HOST_INCLUDE_DIRS}
                     ${ILCLIENT_INCLUDE_DIRS}
                     ${TAGLIB_INCLUDE_DIRS}
+                    ${X11_INCLUDE_DIR}
                     ${include_directory})
 
 link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
@@ -90,4 +92,5 @@ target_link_libraries(ia
                       ${ILCLIENT_LIBRARIES}
                       ${WINSOCK2_LIBRARIES}
                       ${RTAUDIO_LIBRARIES}
-                      ${TAGLIB_LIBRARIES})
+                      ${TAGLIB_LIBRARIES}
+                      ${X11_LIBRARIES})

--- a/assets/icons/dark/widgets-24px.svg
+++ b/assets/icons/dark/widgets-24px.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+    <path fill="none" d="M0 0h24v24H0z"/>
+    <path fill="rgb(255, 255, 255)" d="M13 13v8h8v-8h-8zM3 21h8v-8H3v8zM3 3v8h8V3H3zm13.66-1.31L11 7.34 16.66 13l5.66-5.66-5.66-5.65z"/>
+</svg>

--- a/assets/icons/light/widgets-24px.svg
+++ b/assets/icons/light/widgets-24px.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+    <path fill="none" d="M0 0h24v24H0z"/>
+    <path fill="rgb(0, 0, 0)" d="M13 13v8h8v-8h-8zM3 21h8v-8H3v8zM3 3v8h8V3H3zm13.66-1.31L11 7.34 16.66 13l5.66-5.66-5.66-5.65z"/>
+</svg>

--- a/assets/resources.qrc
+++ b/assets/resources.qrc
@@ -28,6 +28,7 @@
         <file>icons/dark/arrow_drop_up-24px.svg</file>
         <file>icons/dark/arrow_drop_down-24px.svg</file>
         <file>icons/dark/wifi-24px.svg</file>
+        <file>icons/dark/widgets-24px.svg</file>
         <file>icons/light/play-24px.svg</file>
         <file>icons/light/pause-24px.svg</file>
         <file>icons/light/brightness_low-24px.svg</file>
@@ -56,6 +57,7 @@
         <file>icons/light/arrow_drop_up-24px.svg</file>
         <file>icons/light/arrow_drop_down-24px.svg</file>
         <file>icons/light/wifi-24px.svg</file>
+        <file>icons/light/widgets-24px.svg</file>
         <file>stylesheets/light.qss</file>
         <file>stylesheets/dark.qss</file>
         <file>fonts/Titillium_Web/TitilliumWeb-Regular.ttf</file>

--- a/include/app/config.hpp
+++ b/include/app/config.hpp
@@ -56,6 +56,15 @@ class Config : public QObject {
     inline QString get_wireless_address() { return this->wireless_address; }
     inline void set_wireless_address(QString wireless_address) { this->wireless_address = wireless_address; }
 
+    inline QString get_launcher_home() { return this->launcher_home; }
+    inline void set_launcher_home(QString launcher_home) { this->launcher_home = launcher_home; }
+
+    inline bool get_launcher_auto_launch() { return this->launcher_auto_launch; }
+    inline void set_launcher_auto_launch(bool launcher_auto_launch) { this->launcher_auto_launch = launcher_auto_launch; }
+
+    inline QString get_launcher_app() { return this->launcher_app; }
+    inline void set_launcher_app(QString launcher_app) { this->launcher_app = launcher_app; }
+
     std::shared_ptr<f1x::openauto::autoapp::configuration::Configuration> openauto_config;
 
     static Config *get_instance();
@@ -73,6 +82,9 @@ class Config : public QObject {
     QString media_home;
     bool wireless_active;
     QString wireless_address;
+    QString launcher_home;
+    bool launcher_auto_launch;
+    QString launcher_app;
 
    signals:
     void brightness_changed(unsigned int brightness);

--- a/include/app/config.hpp
+++ b/include/app/config.hpp
@@ -62,9 +62,6 @@ class Config : public QObject {
     inline bool get_launcher_auto_launch() { return this->launcher_auto_launch; }
     inline void set_launcher_auto_launch(bool launcher_auto_launch) { this->launcher_auto_launch = launcher_auto_launch; }
 
-    inline int get_launcher_delay() { return this->launcher_delay; }
-    inline void set_launcher_delay(int launcher_delay) { this->launcher_delay = launcher_delay; }
-
     inline QString get_launcher_app() { return this->launcher_app; }
     inline void set_launcher_app(QString launcher_app) { this->launcher_app = launcher_app; }
 
@@ -87,7 +84,6 @@ class Config : public QObject {
     QString wireless_address;
     QString launcher_home;
     bool launcher_auto_launch;
-    int launcher_delay;
     QString launcher_app;
 
    signals:

--- a/include/app/config.hpp
+++ b/include/app/config.hpp
@@ -62,6 +62,9 @@ class Config : public QObject {
     inline bool get_launcher_auto_launch() { return this->launcher_auto_launch; }
     inline void set_launcher_auto_launch(bool launcher_auto_launch) { this->launcher_auto_launch = launcher_auto_launch; }
 
+    inline int get_launcher_delay() { return this->launcher_delay; }
+    inline void set_launcher_delay(int launcher_delay) { this->launcher_delay = launcher_delay; }
+
     inline QString get_launcher_app() { return this->launcher_app; }
     inline void set_launcher_app(QString launcher_app) { this->launcher_app = launcher_app; }
 
@@ -84,6 +87,7 @@ class Config : public QObject {
     QString wireless_address;
     QString launcher_home;
     bool launcher_auto_launch;
+    int launcher_delay;
     QString launcher_app;
 
    signals:

--- a/include/app/tabs/launcher.hpp
+++ b/include/app/tabs/launcher.hpp
@@ -33,11 +33,11 @@ class EmbeddedApp : public QWidget {
 
    private:
     struct WindowProp {
-        WindowProp(char *prop, uint64_t size);
+        WindowProp(char *prop, unsigned long size);
         ~WindowProp();
 
         void *prop;
-        uint64_t size;
+        unsigned long size;
     };
 
     WindowProp get_window_prop(Window window, Atom type, const char *name);

--- a/include/app/tabs/launcher.hpp
+++ b/include/app/tabs/launcher.hpp
@@ -26,10 +26,13 @@ class EmbeddedApp : public QWidget {
     Q_OBJECT
 
    public:
-    EmbeddedApp(QWidget *parent = nullptr);
+    EmbeddedApp(int delay, QWidget *parent = nullptr);
 
     void start(QString app);
     void end();
+
+    inline int get_delay() { return this->delay; }
+    inline void set_delay(int delay) { this->delay = delay; }
 
    private:
     struct WindowProp {
@@ -49,6 +52,7 @@ class EmbeddedApp : public QWidget {
     Window root_window;
     QProcess *process;
     QVBoxLayout *container;
+    int delay;
 
    signals:
     void closed();
@@ -64,6 +68,8 @@ class LauncherTab : public QWidget {
    private:
     QWidget *launcher_widget();
     QWidget *app_select_widget();
+    QWidget *config_widget();
+    QWidget *delay_widget();
     void populate_dirs(QString path);
     void populate_apps(QString path);
 

--- a/include/app/tabs/launcher.hpp
+++ b/include/app/tabs/launcher.hpp
@@ -41,7 +41,6 @@ class XWorker : public QObject {
     };
 
     WindowProp get_window_prop(Window window, Atom type, const char *name);
-    QList<Window> get_clients();
 
     Display *display;
     Window root_window;

--- a/include/app/tabs/launcher.hpp
+++ b/include/app/tabs/launcher.hpp
@@ -1,0 +1,78 @@
+#ifndef LAUNCHER_HPP_
+#define LAUNCHER_HPP_
+
+#include <QProcess>
+#include <QtWidgets>
+
+#include <app/config.hpp>
+#include <app/theme.hpp>
+
+#include <X11/Xatom.h>
+#include <X11/Xlib.h>
+#undef Bool
+#undef CurrentTime
+#undef CursorShape
+#undef Expose
+#undef KeyPress
+#undef KeyRelease
+#undef FocusIn
+#undef FocusOut
+#undef FontChange
+#undef None
+#undef Status
+#undef Unsorted
+
+class EmbeddedApp : public QWidget {
+    Q_OBJECT
+
+   public:
+    EmbeddedApp(QWidget *parent = nullptr);
+
+    void start(QString app);
+    void end();
+
+   private:
+    struct WindowProp {
+        WindowProp(char *prop, uint64_t size);
+        ~WindowProp();
+
+        void *prop;
+        uint64_t size;
+    };
+
+    WindowProp get_window_prop(Window window, Atom type, const char *name);
+    std::list<Window> get_clients();
+    int get_window();
+    QWidget *controls_widget();
+
+    Display *display;
+    Window root_window;
+    QProcess *process;
+    QVBoxLayout *container;
+
+   signals:
+    void closed();
+    void opened();
+};
+
+class LauncherTab : public QWidget {
+    Q_OBJECT
+
+   public:
+    LauncherTab(QWidget *parent = nullptr);
+
+   private:
+    QWidget *launcher_widget();
+    QWidget *app_select_widget();
+    void populate_dirs(QString path);
+    void populate_apps(QString path);
+
+    Theme *theme;
+    Config *config;
+    EmbeddedApp *app;
+    QLabel *path_label;
+    QListWidget *folders;
+    QListWidget *apps;
+};
+
+#endif

--- a/include/app/tabs/launcher.hpp
+++ b/include/app/tabs/launcher.hpp
@@ -22,19 +22,16 @@
 #undef Status
 #undef Unsorted
 
-class EmbeddedApp : public QWidget {
+class XWorker : public QObject {
     Q_OBJECT
 
    public:
-    EmbeddedApp(int delay, QWidget *parent = nullptr);
-
-    void start(QString app);
-    void end();
-
-    inline int get_delay() { return this->delay; }
-    inline void set_delay(int delay) { this->delay = delay; }
+    XWorker(QObject *parent = nullptr);
+    int get_window(uint64_t pid);
 
    private:
+    const int MAX_RETRIES = 60;
+
     struct WindowProp {
         WindowProp(char *prop, unsigned long size);
         ~WindowProp();
@@ -44,15 +41,27 @@ class EmbeddedApp : public QWidget {
     };
 
     WindowProp get_window_prop(Window window, Atom type, const char *name);
-    std::list<Window> get_clients();
-    int get_window();
-    QWidget *controls_widget();
+    QList<Window> get_clients();
 
     Display *display;
     Window root_window;
+};
+
+class EmbeddedApp : public QWidget {
+    Q_OBJECT
+
+   public:
+    EmbeddedApp(QWidget *parent = nullptr);
+
+    void start(QString app);
+    void end();
+
+   private:
+    QWidget *controls_widget();
+
     QProcess *process;
     QVBoxLayout *container;
-    int delay;
+    XWorker *worker;
 
    signals:
     void closed();
@@ -69,7 +78,6 @@ class LauncherTab : public QWidget {
     QWidget *launcher_widget();
     QWidget *app_select_widget();
     QWidget *config_widget();
-    QWidget *delay_widget();
     void populate_dirs(QString path);
     void populate_apps(QString path);
 

--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -22,7 +22,6 @@ Config::Config()
     this->wireless_address = this->ia_config.value("Wireless/address", "0.0.0.0").toString();
     this->launcher_home = this->ia_config.value("Launcher/home", QDir().absolutePath()).toString();
     this->launcher_auto_launch = this->ia_config.value("Launcher/auto_launch", false).toBool();
-    this->launcher_delay = this->ia_config.value("Launcher/delay", 1).toInt();
     this->launcher_app = this->ia_config.value("Launcher/app", false).toString();
 
     QTimer *timer = new QTimer(this);
@@ -58,8 +57,6 @@ void Config::save()
         this->ia_config.setValue("Launcher/home", this->launcher_home);
     if (this->launcher_auto_launch != this->ia_config.value("Launcher/auto_launch", false).toBool())
         this->ia_config.setValue("Launcher/auto_launch", this->launcher_auto_launch);
-    if (this->launcher_delay != this->ia_config.value("Launcher/app", 1).toInt())
-        this->ia_config.setValue("Launcher/delay", this->launcher_delay);
     if (this->launcher_app != this->ia_config.value("Launcher/app", QString()).toString())
         this->ia_config.setValue("Launcher/app", this->launcher_app);
 

--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -22,7 +22,7 @@ Config::Config()
     this->wireless_address = this->ia_config.value("Wireless/address", "0.0.0.0").toString();
     this->launcher_home = this->ia_config.value("Launcher/home", QDir().absolutePath()).toString();
     this->launcher_auto_launch = this->ia_config.value("Launcher/auto_launch", false).toBool();
-    this->launcher_app = this->ia_config.value("Launcher/app", false).toString();
+    this->launcher_app = this->ia_config.value("Launcher/app", QString()).toString();
 
     QTimer *timer = new QTimer(this);
     connect(timer, &QTimer::timeout, [this]() { this->save(); });

--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -20,6 +20,9 @@ Config::Config()
     this->media_home = this->ia_config.value("media_home", QDir().absolutePath()).toString();
     this->wireless_active = this->ia_config.value("Wireless/active", false).toBool();
     this->wireless_address = this->ia_config.value("Wireless/address", "0.0.0.0").toString();
+    this->launcher_home = this->ia_config.value("Launcher/home", QDir().absolutePath()).toString();
+    this->launcher_auto_launch = this->ia_config.value("Launcher/auto_launch", false).toBool();
+    this->launcher_app = this->ia_config.value("Launcher/app", false).toString();
 
     QTimer *timer = new QTimer(this);
     connect(timer, &QTimer::timeout, [this]() { this->save(); });
@@ -50,6 +53,12 @@ void Config::save()
         this->ia_config.setValue("Wireless/active", this->wireless_active);
     if (this->wireless_address != this->ia_config.value("Wireless/address", "0.0.0.0").toBool())
         this->ia_config.setValue("Wireless/address", this->wireless_address);
+    if (this->launcher_home != this->ia_config.value("Launcher/home", QDir().absolutePath()).toString())
+        this->ia_config.setValue("Launcher/home", this->launcher_home);
+    if (this->launcher_auto_launch != this->ia_config.value("Launcher/auto_launch", false).toBool())
+        this->ia_config.setValue("Launcher/auto_launch", this->launcher_auto_launch);
+    if (this->launcher_app != this->ia_config.value("Launcher/app", QString()).toString())
+        this->ia_config.setValue("Launcher/app", this->launcher_app);
 
     this->openauto_config->save();
 }

--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -22,6 +22,7 @@ Config::Config()
     this->wireless_address = this->ia_config.value("Wireless/address", "0.0.0.0").toString();
     this->launcher_home = this->ia_config.value("Launcher/home", QDir().absolutePath()).toString();
     this->launcher_auto_launch = this->ia_config.value("Launcher/auto_launch", false).toBool();
+    this->launcher_delay = this->ia_config.value("Launcher/delay", 1).toInt();
     this->launcher_app = this->ia_config.value("Launcher/app", false).toString();
 
     QTimer *timer = new QTimer(this);
@@ -57,6 +58,8 @@ void Config::save()
         this->ia_config.setValue("Launcher/home", this->launcher_home);
     if (this->launcher_auto_launch != this->ia_config.value("Launcher/auto_launch", false).toBool())
         this->ia_config.setValue("Launcher/auto_launch", this->launcher_auto_launch);
+    if (this->launcher_delay != this->ia_config.value("Launcher/app", 1).toInt())
+        this->ia_config.setValue("Launcher/delay", this->launcher_delay);
     if (this->launcher_app != this->ia_config.value("Launcher/app", QString()).toString())
         this->ia_config.setValue("Launcher/app", this->launcher_app);
 

--- a/src/app/tabs/launcher.cpp
+++ b/src/app/tabs/launcher.cpp
@@ -1,0 +1,258 @@
+#include <app/tabs/launcher.hpp>
+
+EmbeddedApp::WindowProp::WindowProp(char *prop, uint64_t size)
+{
+    this->size = size;
+    this->prop = new char[this->size + 1];
+
+    std::copy(prop, prop + size, (char *)this->prop);
+    ((char *)this->prop)[size] = '\0';
+}
+
+EmbeddedApp::WindowProp::~WindowProp()
+{
+    if (this->prop != nullptr) {
+        delete (char *)this->prop;
+        this->prop = nullptr;
+    }
+}
+
+EmbeddedApp::EmbeddedApp(QWidget *parent) : QWidget(parent)
+{
+    this->display = XOpenDisplay(nullptr);
+    this->root_window = DefaultRootWindow(this->display);
+
+    this->process = new QProcess();
+    process->setStandardOutputFile(QProcess::nullDevice());
+    process->setStandardErrorFile(QProcess::nullDevice());
+
+    QVBoxLayout *layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
+
+    this->container = new QVBoxLayout();
+
+    layout->addWidget(this->controls_widget(), 0, Qt::AlignTop | Qt::AlignRight);
+    layout->addLayout(this->container, 1);
+}
+
+QWidget *EmbeddedApp::controls_widget()
+{
+    QWidget *widget = new QWidget(this);
+
+    QHBoxLayout *layout = new QHBoxLayout(widget);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    QPushButton *button = new QPushButton(this);
+    button->setFlat(true);
+    button->setIconSize(Theme::icon_16);
+    connect(button, &QPushButton::clicked, [this]() { this->end(); });
+    Theme::get_instance()->add_button_icon("close", button);
+    layout->addWidget(button);
+
+    layout->addStretch();
+    layout->addWidget(button);
+
+    return widget;
+}
+
+void EmbeddedApp::start(QString app)
+{
+    this->process->setProgram(app);
+    this->process->start();
+
+    this->process->waitForStarted();
+    sleep(2);
+
+    QWindow *window = QWindow::fromWinId(this->get_window());
+    window->setFlags(Qt::FramelessWindowHint);
+    sleep(2);
+
+    this->container->addWidget(QWidget::createWindowContainer(window, this));
+
+    emit opened();
+}
+
+void EmbeddedApp::end()
+{
+    this->process->terminate();
+    delete this->container->takeAt(0);
+    emit closed();
+}
+
+EmbeddedApp::WindowProp EmbeddedApp::get_window_prop(Window window, Atom type, const char *name)
+{
+    Atom prop = XInternAtom(this->display, name, false);
+
+    Atom actual_type_return;
+    int32_t actual_format_return;
+    uint64_t nitems_return, bytes_after_return;
+    uint8_t *prop_return;
+    XGetWindowProperty(this->display, window, prop, 0, 1024, false, type, &actual_type_return, &actual_format_return,
+                       &nitems_return, &bytes_after_return, &prop_return);
+
+    uint64_t size = (actual_format_return / 8) * nitems_return;
+    if (actual_format_return == 32) size *= sizeof(long) / 4;
+
+    WindowProp winProp((char *)prop_return, size);
+    XFree(prop_return);
+
+    return winProp;
+}
+
+std::list<Window> EmbeddedApp::get_clients()
+{
+    std::list<Window> windows;
+
+    WindowProp prop = this->get_window_prop(this->root_window, XA_WINDOW, "_NET_CLIENT_LIST");
+    Window *window_list = (Window *)prop.prop;
+    for (uint64_t i = 0; i < prop.size / sizeof(Window); i++) windows.push_back(window_list[i]);
+
+    return windows;
+}
+
+int EmbeddedApp::get_window()
+{
+    uint64_t pid;
+    for (auto client : this->get_clients()) {
+        pid = *(uint64_t *)this->get_window_prop(client, XA_CARDINAL, "_NET_WM_PID").prop;
+        if ((uint64_t)this->process->processId() == pid) {
+            return client;
+        }
+    }
+
+    return -1;
+}
+
+LauncherTab::LauncherTab(QWidget *parent) : QWidget(parent)
+{
+    this->theme = Theme::get_instance();
+    this->config = Config::get_instance();
+
+    QStackedLayout *layout = new QStackedLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    this->app = new EmbeddedApp(parent);
+    connect(this->app, &EmbeddedApp::opened, [layout]() { layout->setCurrentIndex(1); });
+    connect(this->app, &EmbeddedApp::closed, [layout]() { layout->setCurrentIndex(0); });
+
+    layout->addWidget(this->launcher_widget());
+    layout->addWidget(this->app);
+
+    if (this->config->get_launcher_auto_launch() && !this->config->get_launcher_app().isEmpty())
+        this->app->start(this->config->get_launcher_app());
+}
+
+QWidget *LauncherTab::launcher_widget()
+{
+    QWidget *widget = new QWidget(this);
+    QVBoxLayout *layout = new QVBoxLayout(widget);
+
+    this->path_label = new QLabel(this->config->get_launcher_home(), this);
+    this->path_label->setFont(Theme::font_14);
+
+    QCheckBox *auto_launch = new QCheckBox("launch at startup", widget);
+    auto_launch->setFont(Theme::font_14);
+    auto_launch->setStyleSheet(QString("QCheckBox::indicator {"
+                                       "    width: %1px;"
+                                       "    height: %1px;"
+                                       "}")
+                                   .arg(Theme::font_14.pointSize()));
+    auto_launch->setChecked(this->config->get_launcher_auto_launch());
+    connect(auto_launch, &QCheckBox::toggled, [this](bool checked) {
+        this->config->set_launcher_auto_launch(checked);
+        QString launcher_app;
+        if (checked) {
+            launcher_app.append(this->path_label->text() + '/');
+            if (this->apps->currentItem() == nullptr)
+                launcher_app.append(this->apps->item(0)->text());
+            else
+                launcher_app.append(this->apps->currentItem()->text());
+        }
+        this->config->set_launcher_app(launcher_app);
+    });
+
+    layout->addStretch(1);
+    layout->addWidget(this->path_label, 1);
+    layout->addWidget(this->app_select_widget(), 4);
+    layout->addWidget(auto_launch, 1, Qt::AlignRight);
+    layout->addStretch(1);
+
+    return widget;
+}
+
+QWidget *LauncherTab::app_select_widget()
+{
+    QWidget *widget = new QWidget(this);
+    QHBoxLayout *layout = new QHBoxLayout(widget);
+
+    QString root_path(this->config->get_launcher_home());
+
+    QPushButton *home_button = new QPushButton(widget);
+    home_button->setFlat(true);
+    home_button->setCheckable(true);
+    home_button->setChecked(this->config->get_launcher_home() == root_path);
+    home_button->setIconSize(Theme::icon_32);
+    connect(home_button, &QPushButton::clicked, [this](bool checked = false) {
+        this->config->set_launcher_home(checked ? this->path_label->text() : QDir().absolutePath());
+    });
+    this->theme->add_button_icon("playlist_add_check", home_button, "playlist_add");
+    layout->addWidget(home_button, 0, Qt::AlignTop);
+
+    this->folders = new QListWidget(widget);
+    Theme::to_touch_scroller(this->folders);
+    this->populate_dirs(root_path);
+    layout->addWidget(this->folders, 4);
+
+    this->apps = new QListWidget(widget);
+    Theme::to_touch_scroller(this->apps);
+    this->populate_apps(root_path);
+    connect(this->apps, &QListWidget::itemClicked, [this](QListWidgetItem *item) {
+        QString app_path = this->path_label->text() + '/' + item->text();
+        if (this->config->get_launcher_auto_launch()) this->config->set_launcher_app(app_path);
+        this->app->start(app_path);
+    });
+    connect(this->folders, &QListWidget::itemClicked, [this, home_button](QListWidgetItem *item) {
+        if (!item->isSelected()) return;
+
+        this->apps->clear();
+        QString current_path(item->data(Qt::UserRole).toString());
+        this->path_label->setText(current_path);
+        this->populate_apps(current_path);
+        this->populate_dirs(current_path);
+
+        home_button->setChecked(this->config->get_launcher_home() == current_path);
+    });
+    layout->addWidget(this->apps, 5);
+
+    return widget;
+}
+
+void LauncherTab::populate_dirs(QString path)
+{
+    this->folders->clear();
+    QDir current_dir(path);
+    for (QFileInfo dir : current_dir.entryInfoList(QDir::AllDirs | QDir::Readable)) {
+        if (dir.fileName() == ".") continue;
+
+        QListWidgetItem *item = new QListWidgetItem(dir.fileName(), this->folders);
+        if (dir.fileName() == "..") {
+            item->setText("↲");
+
+            if (current_dir.isRoot()) item->setFlags(Qt::NoItemFlags);
+        }
+        else {
+            item->setText(dir.fileName());
+        }
+        item->setFont(Theme::font_16);
+        item->setData(Qt::UserRole, QVariant(dir.absoluteFilePath()));
+    }
+}
+
+void LauncherTab::populate_apps(QString path)
+{
+    for (QString app : QDir(path).entryList(QDir::Files | QDir::Executable)) {
+        QListWidgetItem *item = new QListWidgetItem(app, this->apps);
+        item->setFont(Theme::font_16);
+    }
+}

--- a/src/app/tabs/launcher.cpp
+++ b/src/app/tabs/launcher.cpp
@@ -1,3 +1,5 @@
+#include <QElapsedTimer>
+
 #include <app/tabs/launcher.hpp>
 
 EmbeddedApp::WindowProp::WindowProp(char *prop, unsigned long size)
@@ -17,14 +19,17 @@ EmbeddedApp::WindowProp::~WindowProp()
     }
 }
 
-EmbeddedApp::EmbeddedApp(QWidget *parent) : QWidget(parent)
+EmbeddedApp::EmbeddedApp(int delay, QWidget *parent) : QWidget(parent)
 {
+    this->delay = delay;
     this->display = XOpenDisplay(nullptr);
     this->root_window = DefaultRootWindow(this->display);
 
     this->process = new QProcess();
     process->setStandardOutputFile(QProcess::nullDevice());
     process->setStandardErrorFile(QProcess::nullDevice());
+    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            [this](int, QProcess::ExitStatus) { this->end(); });
 
     QVBoxLayout *layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -62,11 +67,11 @@ void EmbeddedApp::start(QString app)
     this->process->start();
 
     this->process->waitForStarted();
-    sleep(2);
+    sleep(this->delay);
 
     QWindow *window = QWindow::fromWinId(this->get_window());
     window->setFlags(Qt::FramelessWindowHint);
-    sleep(2);
+    usleep(500000);
 
     this->container->addWidget(QWidget::createWindowContainer(window, this));
 
@@ -132,7 +137,7 @@ LauncherTab::LauncherTab(QWidget *parent) : QWidget(parent)
     QStackedLayout *layout = new QStackedLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
 
-    this->app = new EmbeddedApp(parent);
+    this->app = new EmbeddedApp(this->config->get_launcher_delay(), parent);
     connect(this->app, &EmbeddedApp::opened, [layout]() { layout->setCurrentIndex(1); });
     connect(this->app, &EmbeddedApp::closed, [layout]() { layout->setCurrentIndex(0); });
 
@@ -151,32 +156,9 @@ QWidget *LauncherTab::launcher_widget()
     this->path_label = new QLabel(this->config->get_launcher_home(), this);
     this->path_label->setFont(Theme::font_14);
 
-    QCheckBox *auto_launch = new QCheckBox("launch at startup", widget);
-    auto_launch->setFont(Theme::font_14);
-    auto_launch->setStyleSheet(QString("QCheckBox::indicator {"
-                                       "    width: %1px;"
-                                       "    height: %1px;"
-                                       "}")
-                                   .arg(Theme::font_14.pointSize()));
-    auto_launch->setChecked(this->config->get_launcher_auto_launch());
-    connect(auto_launch, &QCheckBox::toggled, [this](bool checked) {
-        this->config->set_launcher_auto_launch(checked);
-        QString launcher_app;
-        if (checked) {
-            launcher_app.append(this->path_label->text() + '/');
-            if (this->apps->currentItem() == nullptr)
-                launcher_app.append(this->apps->item(0)->text());
-            else
-                launcher_app.append(this->apps->currentItem()->text());
-        }
-        this->config->set_launcher_app(launcher_app);
-    });
-
-    layout->addStretch(1);
     layout->addWidget(this->path_label, 1);
-    layout->addWidget(this->app_select_widget(), 4);
-    layout->addWidget(auto_launch, 1, Qt::AlignRight);
-    layout->addStretch(1);
+    layout->addWidget(this->app_select_widget(), 6);
+    layout->addWidget(this->config_widget(), 1, Qt::AlignRight);
 
     return widget;
 }
@@ -224,6 +206,66 @@ QWidget *LauncherTab::app_select_widget()
         home_button->setChecked(this->config->get_launcher_home() == current_path);
     });
     layout->addWidget(this->apps, 5);
+
+    return widget;
+}
+
+QWidget *LauncherTab::config_widget()
+{
+    QWidget *widget = new QWidget(this);
+    QVBoxLayout *layout = new QVBoxLayout(widget);
+    layout->setSpacing(0);
+
+    QCheckBox *checkbox = new QCheckBox("launch at startup", widget);
+    checkbox->setFont(Theme::font_14);
+    checkbox->setStyleSheet(QString("QCheckBox::indicator {"
+                                    "    width: %1px;"
+                                    "    height: %1px;"
+                                    "}")
+                                .arg(Theme::font_14.pointSize()));
+    checkbox->setChecked(this->config->get_launcher_auto_launch());
+    connect(checkbox, &QCheckBox::toggled, [this](bool checked) {
+        this->config->set_launcher_auto_launch(checked);
+        QString launcher_app;
+        if (checked) {
+            launcher_app.append(this->path_label->text() + '/');
+            if (this->apps->currentItem() == nullptr)
+                launcher_app.append(this->apps->item(0)->text());
+            else
+                launcher_app.append(this->apps->currentItem()->text());
+        }
+        this->config->set_launcher_app(launcher_app);
+    });
+
+    layout->addWidget(checkbox);
+    layout->addWidget(this->delay_widget());
+
+    return widget;
+}
+
+QWidget *LauncherTab::delay_widget()
+{
+    QWidget *widget = new QWidget(this);
+    QHBoxLayout *layout = new QHBoxLayout(widget);
+    layout->addStretch();
+    layout->setSpacing(0);
+
+    QPushButton *button = new QPushButton(QString::number(this->app->get_delay()), widget);
+    button->setFont(QFont("Titillium Web", 18));
+    button->setFlat(true);
+    QElapsedTimer *timer = new QElapsedTimer();
+    connect(button, &QPushButton::pressed, [timer]() { timer->start(); });
+    connect(button, &QPushButton::released, [this, timer, button]() {
+        int delay = timer->hasExpired(500) ? 1 : (button->text().toInt() + 1);
+        button->setText(QString::number(delay));
+        this->app->set_delay(delay);
+        this->config->set_launcher_delay(delay);
+    });
+    layout->addWidget(button);
+
+    QLabel *label = new QLabel("s delay", widget);
+    label->setFont(Theme::font_14);
+    layout->addWidget(label);
 
     return widget;
 }

--- a/src/app/tabs/launcher.cpp
+++ b/src/app/tabs/launcher.cpp
@@ -1,6 +1,6 @@
 #include <app/tabs/launcher.hpp>
 
-EmbeddedApp::WindowProp::WindowProp(char *prop, uint64_t size)
+EmbeddedApp::WindowProp::WindowProp(char *prop, unsigned long size)
 {
     this->size = size;
     this->prop = new char[this->size + 1];
@@ -85,19 +85,19 @@ EmbeddedApp::WindowProp EmbeddedApp::get_window_prop(Window window, Atom type, c
     Atom prop = XInternAtom(this->display, name, false);
 
     Atom actual_type_return;
-    int32_t actual_format_return;
-    uint64_t nitems_return, bytes_after_return;
-    uint8_t *prop_return;
+    int actual_format_return;
+    unsigned long nitems_return, bytes_after_return;
+    unsigned char *prop_return;
     XGetWindowProperty(this->display, window, prop, 0, 1024, false, type, &actual_type_return, &actual_format_return,
                        &nitems_return, &bytes_after_return, &prop_return);
 
-    uint64_t size = (actual_format_return / 8) * nitems_return;
+    unsigned long size = (actual_format_return / 8) * nitems_return;
     if (actual_format_return == 32) size *= sizeof(long) / 4;
 
-    WindowProp winProp((char *)prop_return, size);
+    WindowProp window_prop((char *)prop_return, size);
     XFree(prop_return);
 
-    return winProp;
+    return window_prop;
 }
 
 std::list<Window> EmbeddedApp::get_clients()
@@ -106,7 +106,7 @@ std::list<Window> EmbeddedApp::get_clients()
 
     WindowProp prop = this->get_window_prop(this->root_window, XA_WINDOW, "_NET_CLIENT_LIST");
     Window *window_list = (Window *)prop.prop;
-    for (uint64_t i = 0; i < prop.size / sizeof(Window); i++) windows.push_back(window_list[i]);
+    for (unsigned long i = 0; i < prop.size / sizeof(Window); i++) windows.push_back(window_list[i]);
 
     return windows;
 }

--- a/src/app/window.cpp
+++ b/src/app/window.cpp
@@ -5,6 +5,7 @@
 
 #include <app/tabs/data.hpp>
 #include <app/tabs/media.hpp>
+#include <app/tabs/launcher.hpp>
 #include <app/tabs/settings.hpp>
 #include <app/window.hpp>
 
@@ -55,8 +56,11 @@ QTabWidget *MainWindow::tabs_widget()
     widget->addTab(new DataTab(this), QString());
     this->theme->add_tab_icon("speed", 2, Qt::Orientation::Vertical);
 
+    widget->addTab(new LauncherTab(this), "");
+    this->theme->add_tab_icon("widgets", 3, Qt::Orientation::Vertical);
+
     widget->addTab(new SettingsTab(this), "");
-    this->theme->add_tab_icon("tune", 3, Qt::Orientation::Vertical);
+    this->theme->add_tab_icon("tune", 4, Qt::Orientation::Vertical);
 
     connect(this->config, &Config::brightness_changed, [this, widget](int position) {
         this->setWindowOpacity(position / 255.0);

--- a/src/app/window.cpp
+++ b/src/app/window.cpp
@@ -103,13 +103,13 @@ QWidget *MainWindow::controls_widget()
     this->theme->add_button_icon("close", exit_button);
     connect(exit_button, &QPushButton::clicked, []() { qApp->exit(); });
 
-    QElapsedTimer timer;
-    connect(shutdown_button, &QPushButton::pressed, [&timer]() { timer.start(); });
-    connect(shutdown_button, &QPushButton::released, [&timer]() {
+    QElapsedTimer *timer = new QElapsedTimer();
+    connect(shutdown_button, &QPushButton::pressed, [timer]() { timer->start(); });
+    connect(shutdown_button, &QPushButton::released, [timer]() {
         sync();
 
         std::stringstream cmd;
-        cmd << "shutdown -" << (timer.hasExpired(2000) ? 'r' : 'h') << " now";
+        cmd << "shutdown -" << (timer->hasExpired(2000) ? 'r' : 'h') << " now";
         if (system(cmd.str().c_str()) < 0) qApp->exit();
     });
 


### PR DESCRIPTION
Adding an app launcher with auto-launch functionality.

some caveats:

- user currently has free reign to launch any executable they want, so be careful (nothing bad will really happen, but if they try to launch an executable that doesn't have a UI, they wont see anything). I'm thinking an additional feature could be to redirect the stdout/stderr to an additional tab to sort of act as a dumb terminal.
- launching an app will halt the rest of the program. Not sure if this is a bad thing, but later I want to do some more research into possibly making it run as a background process until the window is ready.

Also think it would be cool to make a more "friendly" app selector, but that will require a bit more effort to refactor and make it useable for the local media player as well.