### PR TITLE
sync openauto night mode with dark mode

### DIFF
--- a/include/app/tabs/openauto.hpp
+++ b/include/app/tabs/openauto.hpp
@@ -15,6 +15,9 @@
 #include <f1x/openauto/autoapp/Service/AndroidAutoEntityFactory.hpp>
 #include <f1x/openauto/autoapp/Service/ServiceFactory.hpp>
 
+#include <app/config.hpp>
+#include <app/theme.hpp>
+
 namespace aasdk = f1x::aasdk;
 namespace autoapp = f1x::openauto::autoapp;
 
@@ -22,7 +25,7 @@ class OpenAutoWorker : public QObject {
     Q_OBJECT
 
    public:
-    OpenAutoWorker(std::function<void(bool)> callback = nullptr, QWidget *parent = nullptr);
+    OpenAutoWorker(std::function<void(bool)> callback = nullptr, QWidget *parent = nullptr, bool night_mode = false);
     ~OpenAutoWorker();
     const QStringList get_recent_addresses();
     void connect_wireless(QString address);
@@ -30,6 +33,7 @@ class OpenAutoWorker : public QObject {
     inline void start() { this->app->waitForUSBDevice(); }
     inline void set_opacity(unsigned int alpha) { this->service_factory.setOpacity(alpha); }
     inline void resize() { this->service_factory.resize(); }
+    inline void set_night_mode(bool mode) { this->service_factory.setNightMode(mode); }
 
    private:
     const int OPENAUTO_PORT = 5277;
@@ -90,6 +94,7 @@ class OpenAutoTab : public QWidget {
     QWidget *wireless_widget();
 
     Config *config;
+    Theme *theme;
     OpenAutoWorker *worker = nullptr;
 
    signals:

--- a/include/app/theme.hpp
+++ b/include/app/theme.hpp
@@ -41,6 +41,7 @@ class Theme : public QObject {
 
     Theme();
 
+    inline bool get_mode() { return this->mode; }
     inline void set_mode(bool mode)
     {
         this->mode = mode;
@@ -109,6 +110,7 @@ class Theme : public QObject {
     QPixmap create_pixmap_variant(QPixmap &base, qreal opacity);
 
    signals:
+    void mode_updated(bool mode);
     void icons_updated(QList<tab_icon_t> &, QList<button_icon_t> &);
     void color_updated();
 };

--- a/src/app/theme.cpp
+++ b/src/app/theme.cpp
@@ -153,6 +153,7 @@ void Theme::update()
     this->set_palette();
     qApp->setStyleSheet(this->stylesheets[this->mode ? "dark" : "light"]);
 
+    emit mode_updated(this->mode);
     emit icons_updated(this->tab_icons[this->mode ? "dark" : "light"],
                        this->button_icons[this->mode ? "dark" : "light"]);
     emit color_updated();


### PR DESCRIPTION
Dark mode will now be synced with openauto night mode.

NOTE for this to work you'll need to go into the developer setting of Android Auto and set the night mode to be controlled by the car.

The original plan was to allow night mode to either be synced from phone->car (for that sweet automatic dark mode when the sun goes down) or car->phone but it doesn't seem like there is an indication of when night mode changes. 

You can still probably work around that by continuously polling the night mode status, but that just seems like a major hack and I was not a fan of that approach. It may just be better to include an automatic "sun goes down" mode in ia that will automatically adjust to based on time of day.

But for those who plan on using other indicators (like light sensors and stuff) they would want to control the syncing anyway.