### PR TITLE
add module support for brightness and quick view

### DIFF
--- a/include/app/config.hpp
+++ b/include/app/config.hpp
@@ -67,11 +67,13 @@ class Config : public QObject {
         emit quick_view_changed(this->quick_view);
     }
     inline QMap<QString, QWidget *> get_quick_views() { return this->quick_views; }
+    inline QWidget *get_quick_view(QString name) { return this->quick_views[name]; }
     inline void add_quick_view(QString name, QWidget *view) { this->quick_views[name] = view; }
 
     inline QString get_brightness_module() { return this->brightness_module; }
     inline void set_brightness_module(QString brightness_module) { this->brightness_module = brightness_module; }
     inline QMap<QString, BrightnessModule *> get_brightness_modules() { return this->brightness_modules; }
+    inline BrightnessModule *get_brightness_module(QString name) { return this->brightness_modules[name]; }
     inline void add_brightness_module(QString name, BrightnessModule *module)
     {
         this->brightness_modules[name] = module;

--- a/include/app/config.hpp
+++ b/include/app/config.hpp
@@ -9,6 +9,8 @@
 #include <QSettings>
 #include <QString>
 
+#include <app/modules/brightness.hpp>
+
 class Config : public QObject {
     Q_OBJECT
 
@@ -58,22 +60,30 @@ class Config : public QObject {
     inline QString get_wireless_address() { return this->wireless_address; }
     inline void set_wireless_address(QString wireless_address) { this->wireless_address = wireless_address; }
 
-    inline QString get_quick_control() { return this->quick_control; }
-    inline void set_quick_control(QString quick_control)
+    inline QString get_quick_view() { return this->quick_view; }
+    inline void set_quick_view(QString quick_view)
     {
-        this->quick_control = quick_control;
-        emit quick_control_changed(this->quick_control);
+        this->quick_view = quick_view;
+        emit quick_view_changed(this->quick_view);
     }
+    inline QMap<QString, QWidget *> get_quick_views() { return this->quick_views; }
+    inline void add_quick_view(QString name, QWidget *view) { this->quick_views[name] = view; }
 
-    inline QMap<QString, QWidget *> get_quick_controls() { return this->quick_controls; }
-    inline void add_quick_control(QString name, QWidget *widget) { this->quick_controls[name] = widget; }
+    inline QString get_brightness_module() { return this->brightness_module; }
+    inline void set_brightness_module(QString brightness_module) { this->brightness_module = brightness_module; }
+    inline QMap<QString, BrightnessModule *> get_brightness_modules() { return this->brightness_modules; }
+    inline void add_brightness_module(QString name, BrightnessModule *module)
+    {
+        this->brightness_modules[name] = module;
+    }
 
     std::shared_ptr<f1x::openauto::autoapp::configuration::Configuration> openauto_config;
 
     static Config *get_instance();
 
    private:
-    QMap<QString, QWidget *> quick_controls = {{"none", new QFrame()}};
+    QMap<QString, QWidget *> quick_views;
+    QMap<QString, BrightnessModule *> brightness_modules;
 
     QSettings ia_config;
     int volume;
@@ -87,12 +97,13 @@ class Config : public QObject {
     QString media_home;
     bool wireless_active;
     QString wireless_address;
-    QString quick_control;
+    QString quick_view;
+    QString brightness_module;
 
    signals:
     void brightness_changed(unsigned int brightness);
     void si_units_changed(bool si_units);
-    void quick_control_changed(QString quick_control);
+    void quick_view_changed(QString quick_view);
 };
 
 #endif

--- a/include/app/config.hpp
+++ b/include/app/config.hpp
@@ -4,6 +4,8 @@
 #include <f1x/openauto/autoapp/Configuration/Configuration.hpp>
 
 #include <QObject>
+#include <QWidget>
+#include <QFrame>
 #include <QSettings>
 #include <QString>
 
@@ -56,11 +58,23 @@ class Config : public QObject {
     inline QString get_wireless_address() { return this->wireless_address; }
     inline void set_wireless_address(QString wireless_address) { this->wireless_address = wireless_address; }
 
+    inline QString get_quick_control() { return this->quick_control; }
+    inline void set_quick_control(QString quick_control)
+    {
+        this->quick_control = quick_control;
+        emit quick_control_changed(this->quick_control);
+    }
+
+    inline QMap<QString, QWidget *> get_quick_controls() { return this->quick_controls; }
+    inline void add_quick_control(QString name, QWidget *widget) { this->quick_controls[name] = widget; }
+
     std::shared_ptr<f1x::openauto::autoapp::configuration::Configuration> openauto_config;
 
     static Config *get_instance();
 
    private:
+    QMap<QString, QWidget *> quick_controls = {{"none", new QFrame()}};
+
     QSettings ia_config;
     int volume;
     bool dark_mode;
@@ -73,10 +87,12 @@ class Config : public QObject {
     QString media_home;
     bool wireless_active;
     QString wireless_address;
+    QString quick_control;
 
    signals:
     void brightness_changed(unsigned int brightness);
     void si_units_changed(bool si_units);
+    void quick_control_changed(QString quick_control);
 };
 
 #endif

--- a/include/app/modules/brightness.hpp
+++ b/include/app/modules/brightness.hpp
@@ -1,8 +1,8 @@
 #ifndef BRIGHTNESS_HPP_
 #define BRIGHTNESS_HPP_
 
-#include <QObject>
 #include <QMainWindow>
+#include <QObject>
 #include <QScreen>
 
 class BrightnessModule : public QObject {
@@ -12,24 +12,19 @@ class BrightnessModule : public QObject {
     BrightnessModule(QMainWindow *window);
 
     virtual void set_brightness(int brightness) = 0;
-    bool do_update_androidauto() { return this->update_androidauto; }
+    bool update_androidauto() { return false; }
 
    protected:
     QMainWindow *window;
-
-   private:
-    bool update_androidauto = false;
 };
 
 class MockedBrightnessModule : public BrightnessModule {
     Q_OBJECT
 
-    public:
+   public:
     MockedBrightnessModule(QMainWindow *window) : BrightnessModule(window) {}
     void set_brightness(int brightness);
-
-   private:
-    bool update_androidauto = true;
+    bool update_androidauto() { return true; }
 };
 
 // class RpiOfficialBrightnessModule : public BrightnessModule {

--- a/include/app/modules/brightness.hpp
+++ b/include/app/modules/brightness.hpp
@@ -1,0 +1,53 @@
+#ifndef BRIGHTNESS_HPP_
+#define BRIGHTNESS_HPP_
+
+#include <QObject>
+#include <QMainWindow>
+#include <QScreen>
+
+class BrightnessModule : public QObject {
+    Q_OBJECT
+
+   public:
+    BrightnessModule(QMainWindow *window);
+
+    virtual int get_brightness() = 0;
+    virtual void set_brightness(int brightness) = 0;
+    bool do_update_androidauto() { return this->update_androidauto; }
+
+   protected:
+    QMainWindow *window;
+
+   private:
+    bool update_androidauto = false;
+};
+
+class MockedBrightnessModule : public BrightnessModule {
+    Q_OBJECT
+
+    public:
+    MockedBrightnessModule(QMainWindow *window) : BrightnessModule(window) {}
+    int get_brightness();
+    void set_brightness(int brightness);
+
+   private:
+    bool update_androidauto = true;
+};
+
+// class RpiOfficialBrightnessModule : public BrightnessModule {
+//     Q_OBJECT
+// };
+
+class XBrightnessModule : public BrightnessModule {
+    Q_OBJECT
+
+   public:
+    XBrightnessModule(QMainWindow *window);
+    int get_brightness();
+    void set_brightness(int brightness);
+
+   private:
+    QScreen *screen;
+};
+
+#endif

--- a/include/app/modules/brightness.hpp
+++ b/include/app/modules/brightness.hpp
@@ -9,13 +9,10 @@ class BrightnessModule : public QObject {
     Q_OBJECT
 
    public:
-    BrightnessModule(QMainWindow *window, bool enable_androidauto_update = false);
+    BrightnessModule(bool enable_androidauto_update);
 
     virtual void set_brightness(int brightness) = 0;
-    bool update_androidauto() { return this->enable_androidauto_update; }
-
-   protected:
-    QMainWindow *window;
+    inline bool update_androidauto() { return this->enable_androidauto_update; }
 
    private:
     bool enable_androidauto_update;
@@ -25,19 +22,26 @@ class MockedBrightnessModule : public BrightnessModule {
     Q_OBJECT
 
    public:
-    MockedBrightnessModule(QMainWindow *window) : BrightnessModule(window, true) {}
+    MockedBrightnessModule(QMainWindow *window);
     void set_brightness(int brightness);
+
+   private:
+    QMainWindow *window;
 };
 
-// class RpiOfficialBrightnessModule : public BrightnessModule {
-//     Q_OBJECT
-// };
+class RpiBrightnessModule : public BrightnessModule {
+    Q_OBJECT
+
+   public:
+    RpiBrightnessModule() : BrightnessModule(false) {}
+    void set_brightness(int brightness);
+};
 
 class XBrightnessModule : public BrightnessModule {
     Q_OBJECT
 
    public:
-    XBrightnessModule(QMainWindow *window);
+    XBrightnessModule();
     void set_brightness(int brightness);
 
    private:

--- a/include/app/modules/brightness.hpp
+++ b/include/app/modules/brightness.hpp
@@ -4,7 +4,7 @@
 #include <QMainWindow>
 #include <QObject>
 #include <QScreen>
-#include <QTextStream>
+#include <QFile>
 
 class BrightnessModule : public QObject {
     Q_OBJECT
@@ -42,7 +42,7 @@ class RpiBrightnessModule : public BrightnessModule {
    private:
     const QString PATH = "/sys/class/backlight/rpi_backlight/brightness";
 
-    QTextStream stream;
+    QFile brightness_attribute;
 };
 
 class XBrightnessModule : public BrightnessModule {

--- a/include/app/modules/brightness.hpp
+++ b/include/app/modules/brightness.hpp
@@ -9,22 +9,24 @@ class BrightnessModule : public QObject {
     Q_OBJECT
 
    public:
-    BrightnessModule(QMainWindow *window);
+    BrightnessModule(QMainWindow *window, bool enable_androidauto_update = false);
 
     virtual void set_brightness(int brightness) = 0;
-    bool update_androidauto() { return false; }
+    bool update_androidauto() { return this->enable_androidauto_update; }
 
    protected:
     QMainWindow *window;
+
+   private:
+    bool enable_androidauto_update;
 };
 
 class MockedBrightnessModule : public BrightnessModule {
     Q_OBJECT
 
    public:
-    MockedBrightnessModule(QMainWindow *window) : BrightnessModule(window) {}
+    MockedBrightnessModule(QMainWindow *window) : BrightnessModule(window, true) {}
     void set_brightness(int brightness);
-    bool update_androidauto() { return true; }
 };
 
 // class RpiOfficialBrightnessModule : public BrightnessModule {

--- a/include/app/modules/brightness.hpp
+++ b/include/app/modules/brightness.hpp
@@ -4,6 +4,7 @@
 #include <QMainWindow>
 #include <QObject>
 #include <QScreen>
+#include <QTextStream>
 
 class BrightnessModule : public QObject {
     Q_OBJECT
@@ -33,8 +34,15 @@ class RpiBrightnessModule : public BrightnessModule {
     Q_OBJECT
 
    public:
-    RpiBrightnessModule() : BrightnessModule(false) {}
+    RpiBrightnessModule();
+    ~RpiBrightnessModule();
+
     void set_brightness(int brightness);
+
+   private:
+    const QString PATH = "/sys/class/backlight/rpi_backlight/brightness";
+
+    QTextStream stream;
 };
 
 class XBrightnessModule : public BrightnessModule {

--- a/include/app/modules/brightness.hpp
+++ b/include/app/modules/brightness.hpp
@@ -11,7 +11,6 @@ class BrightnessModule : public QObject {
    public:
     BrightnessModule(QMainWindow *window);
 
-    virtual int get_brightness() = 0;
     virtual void set_brightness(int brightness) = 0;
     bool do_update_androidauto() { return this->update_androidauto; }
 
@@ -27,7 +26,6 @@ class MockedBrightnessModule : public BrightnessModule {
 
     public:
     MockedBrightnessModule(QMainWindow *window) : BrightnessModule(window) {}
-    int get_brightness();
     void set_brightness(int brightness);
 
    private:
@@ -43,7 +41,6 @@ class XBrightnessModule : public BrightnessModule {
 
    public:
     XBrightnessModule(QMainWindow *window);
-    int get_brightness();
     void set_brightness(int brightness);
 
    private:

--- a/include/app/tabs/settings.hpp
+++ b/include/app/tabs/settings.hpp
@@ -31,8 +31,8 @@ class GeneralSettingsSubTab : public QWidget {
     QWidget *si_units_row_widget();
     QWidget *color_row_widget();
     QWidget *color_select_widget();
-    QWidget *quick_control_row_widget();
-    QWidget *quick_control_select_widget();
+    QWidget *quick_view_row_widget();
+    QWidget *quick_view_select_widget();
 
     Config *config;
     Theme *theme;

--- a/include/app/tabs/settings.hpp
+++ b/include/app/tabs/settings.hpp
@@ -29,6 +29,8 @@ class GeneralSettingsSubTab : public QWidget {
     QWidget *si_units_row_widget();
     QWidget *color_row_widget();
     QWidget *color_select_widget();
+    QWidget *quick_control_row_widget();
+    QWidget *quick_control_select_widget();
 
     Config *config;
     Theme *theme;

--- a/include/app/tabs/settings.hpp
+++ b/include/app/tabs/settings.hpp
@@ -24,6 +24,8 @@ class GeneralSettingsSubTab : public QWidget {
    private:
     QWidget *settings_widget();
     QWidget *dark_mode_row_widget();
+    QWidget *brightness_module_row_widget();
+    QWidget *brightness_module_select_widget();
     QWidget *brightness_row_widget();
     QWidget *brightness_widget();
     QWidget *si_units_row_widget();

--- a/include/app/window.hpp
+++ b/include/app/window.hpp
@@ -33,6 +33,7 @@ class MainWindow : public QMainWindow {
     QWidget *window_widget();
     QTabWidget *tabs_widget();
     QWidget *controls_widget();
+    QWidget *quick_control_widget();
     QWidget *volume_widget();
 
     Config *config;

--- a/include/app/window.hpp
+++ b/include/app/window.hpp
@@ -33,7 +33,7 @@ class MainWindow : public QMainWindow {
     QWidget *window_widget();
     QTabWidget *tabs_widget();
     QWidget *controls_widget();
-    QWidget *quick_control_widget();
+    QWidget *quick_view_widget();
     QWidget *volume_widget();
 
     Config *config;

--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -20,7 +20,7 @@ Config::Config()
     this->media_home = this->ia_config.value("media_home", QDir().absolutePath()).toString();
     this->wireless_active = this->ia_config.value("Wireless/active", false).toBool();
     this->wireless_address = this->ia_config.value("Wireless/address", "0.0.0.0").toString();
-    this->quick_view = this->ia_config.value("quick_view", "none").toString();
+    this->quick_view = this->ia_config.value("quick_view", "volume").toString();
     this->brightness_module = this->ia_config.value("brightness_module", "mocked").toString();
 
     QTimer *timer = new QTimer(this);
@@ -52,7 +52,7 @@ void Config::save()
         this->ia_config.setValue("Wireless/active", this->wireless_active);
     if (this->wireless_address != this->ia_config.value("Wireless/address", "0.0.0.0").toString())
         this->ia_config.setValue("Wireless/address", this->wireless_address);
-    if (this->quick_view != this->ia_config.value("quick_view", "none").toString())
+    if (this->quick_view != this->ia_config.value("quick_view", "volume").toString())
         this->ia_config.setValue("quick_view", this->quick_view);
     if (this->brightness_module != this->ia_config.value("brightness_module", "mocked").toString())
         this->ia_config.setValue("brightness_module", this->brightness_module);

--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -20,6 +20,7 @@ Config::Config()
     this->media_home = this->ia_config.value("media_home", QDir().absolutePath()).toString();
     this->wireless_active = this->ia_config.value("Wireless/active", false).toBool();
     this->wireless_address = this->ia_config.value("Wireless/address", "0.0.0.0").toString();
+    this->quick_control = this->ia_config.value("quick_control", "none").toString();
 
     QTimer *timer = new QTimer(this);
     connect(timer, &QTimer::timeout, [this]() { this->save(); });
@@ -48,8 +49,10 @@ void Config::save()
         this->ia_config.setValue("media_home", this->media_home);
     if (this->wireless_active != this->ia_config.value("Wireless/active", false).toBool())
         this->ia_config.setValue("Wireless/active", this->wireless_active);
-    if (this->wireless_address != this->ia_config.value("Wireless/address", "0.0.0.0").toBool())
+    if (this->wireless_address != this->ia_config.value("Wireless/address", "0.0.0.0").toString())
         this->ia_config.setValue("Wireless/address", this->wireless_address);
+    if (this->quick_control != this->ia_config.value("quick_control", "none").toString())
+        this->ia_config.setValue("quick_control", this->quick_control);
 
     this->openauto_config->save();
 }

--- a/src/app/config.cpp
+++ b/src/app/config.cpp
@@ -20,7 +20,8 @@ Config::Config()
     this->media_home = this->ia_config.value("media_home", QDir().absolutePath()).toString();
     this->wireless_active = this->ia_config.value("Wireless/active", false).toBool();
     this->wireless_address = this->ia_config.value("Wireless/address", "0.0.0.0").toString();
-    this->quick_control = this->ia_config.value("quick_control", "none").toString();
+    this->quick_view = this->ia_config.value("quick_view", "none").toString();
+    this->brightness_module = this->ia_config.value("brightness_module", "mocked").toString();
 
     QTimer *timer = new QTimer(this);
     connect(timer, &QTimer::timeout, [this]() { this->save(); });
@@ -51,8 +52,10 @@ void Config::save()
         this->ia_config.setValue("Wireless/active", this->wireless_active);
     if (this->wireless_address != this->ia_config.value("Wireless/address", "0.0.0.0").toString())
         this->ia_config.setValue("Wireless/address", this->wireless_address);
-    if (this->quick_control != this->ia_config.value("quick_control", "none").toString())
-        this->ia_config.setValue("quick_control", this->quick_control);
+    if (this->quick_view != this->ia_config.value("quick_view", "none").toString())
+        this->ia_config.setValue("quick_view", this->quick_view);
+    if (this->brightness_module != this->ia_config.value("brightness_module", "mocked").toString())
+        this->ia_config.setValue("brightness_module", this->brightness_module);
 
     this->openauto_config->save();
 }

--- a/src/app/modules/brightness.cpp
+++ b/src/app/modules/brightness.cpp
@@ -14,27 +14,22 @@ MockedBrightnessModule::MockedBrightnessModule(QMainWindow *window) : Brightness
 
 void MockedBrightnessModule::set_brightness(int brightness) { this->window->setWindowOpacity(brightness / 255.0); }
 
-RpiBrightnessModule::RpiBrightnessModule() : BrightnessModule(false), stream(new QFile(this->PATH))
+RpiBrightnessModule::RpiBrightnessModule() : BrightnessModule(false), brightness_attribute(this->PATH)
 {
-    if (!this->stream.device()->open(QIODevice::ReadWrite | QIODevice::ExistingOnly))
-        printf("\nFAILED TO OPEN BRIGHTNESS FILE\n\n");
+    this->brightness_attribute.open(QIODevice::WriteOnly | QIODevice::ExistingOnly);
 }
 
 RpiBrightnessModule::~RpiBrightnessModule()
 {
-    QIODevice *device = this->stream.device();
-    if (device->isOpen()) device->close();
+    if (this->brightness_attribute.isOpen()) this->brightness_attribute.close();
 }
 
 void RpiBrightnessModule::set_brightness(int brightness)
 {
-    QFileDevice *device = qobject_cast<QFileDevice *>(this->stream.device());
-    if (device->isOpen()) {
-        printf("\nRESIZE BRIGHTNESS FILE STATUS: %d\n\n", device->resize(0));
-        this->stream << brightness << endl;
-    }
-    else {
-        printf("\nBRIGHTNESS FILE IS NOT OPEN\n\n");
+    if (this->brightness_attribute.isOpen()) {
+        this->brightness_attribute.reset();
+        this->brightness_attribute.write(std::to_string(brightness).c_str());
+        this->brightness_attribute.flush();
     }
 }
 

--- a/src/app/modules/brightness.cpp
+++ b/src/app/modules/brightness.cpp
@@ -16,7 +16,8 @@ void MockedBrightnessModule::set_brightness(int brightness) { this->window->setW
 
 RpiBrightnessModule::RpiBrightnessModule() : BrightnessModule(false), stream(new QFile(this->PATH))
 {
-    this->stream.device()->open(QIODevice::ReadWrite | QIODevice::ExistingOnly);
+    if (!this->stream.device()->open(QIODevice::ReadWrite | QIODevice::ExistingOnly))
+        printf("\nFAILED TO OPEN BRIGHTNESS FILE\n\n");
 }
 
 RpiBrightnessModule::~RpiBrightnessModule()
@@ -29,8 +30,11 @@ void RpiBrightnessModule::set_brightness(int brightness)
 {
     QFileDevice *device = qobject_cast<QFileDevice *>(this->stream.device());
     if (device->isOpen()) {
-        device->resize(0);
+        printf("\nRESIZE BRIGHTNESS FILE STATUS: %d\n\n", device->resize(0));
         this->stream << brightness << endl;
+    }
+    else {
+        printf("\nBRIGHTNESS FILE IS NOT OPEN\n\n");
     }
 }
 

--- a/src/app/modules/brightness.cpp
+++ b/src/app/modules/brightness.cpp
@@ -16,7 +16,7 @@ void MockedBrightnessModule::set_brightness(int brightness) { this->window->setW
 
 RpiBrightnessModule::RpiBrightnessModule() : BrightnessModule(false), stream(new QFile(this->PATH))
 {
-    this->stream.device()->open(QIODevice::WriteOnly | QIODevice::ExistingOnly);
+    this->stream.device()->open(QIODevice::ReadWrite | QIODevice::ExistingOnly);
 }
 
 RpiBrightnessModule::~RpiBrightnessModule()

--- a/src/app/modules/brightness.cpp
+++ b/src/app/modules/brightness.cpp
@@ -1,0 +1,35 @@
+#include <QApplication>
+#include <QProcess>
+#include <QWindow>
+#include <QDebug>
+
+#include <app/modules/brightness.hpp>
+
+BrightnessModule::BrightnessModule(QMainWindow *window) : QObject(qApp) { this->window = window; }
+
+int MockedBrightnessModule::get_brightness() { return this->window->windowOpacity() * 255; }
+
+void MockedBrightnessModule::set_brightness(int brightness) { this->window->setWindowOpacity(brightness / 255.0); }
+
+XBrightnessModule::XBrightnessModule(QMainWindow *window) : BrightnessModule(window)
+{
+    this->screen = qApp->screens()[0];
+}
+
+int XBrightnessModule::get_brightness()
+{
+    QProcess process(this);
+    process.start("xrandr --current --verbose");
+    process.waitForFinished();
+    qDebug() << process.readAllStandardOutput();
+
+    return 255;
+
+}
+
+void XBrightnessModule::set_brightness(int brightness)
+{
+    QProcess process(this);
+    process.start(QString("xrandr --output %1 --brightness %2").arg(this->screen->name()).arg(brightness / 255.0));
+    process.waitForFinished();
+}

--- a/src/app/modules/brightness.cpp
+++ b/src/app/modules/brightness.cpp
@@ -5,7 +5,11 @@
 
 #include <app/modules/brightness.hpp>
 
-BrightnessModule::BrightnessModule(QMainWindow *window) : QObject(qApp) { this->window = window; }
+BrightnessModule::BrightnessModule(QMainWindow *window, bool enable_androidauto_update) : QObject(qApp)
+{
+	this->window = window;
+	this->enable_androidauto_update = enable_androidauto_update;
+}
 
 void MockedBrightnessModule::set_brightness(int brightness) { this->window->setWindowOpacity(brightness / 255.0); }
 

--- a/src/app/modules/brightness.cpp
+++ b/src/app/modules/brightness.cpp
@@ -1,21 +1,28 @@
-#include <QApplication>
+#include <QGuiApplication>
 #include <QProcess>
 #include <QWindow>
-#include <QDebug>
 
 #include <app/modules/brightness.hpp>
 
-BrightnessModule::BrightnessModule(QMainWindow *window, bool enable_androidauto_update) : QObject(qApp)
+BrightnessModule::BrightnessModule(bool enable_androidauto_update) : QObject(qApp)
 {
-	this->window = window;
-	this->enable_androidauto_update = enable_androidauto_update;
+    this->enable_androidauto_update = enable_androidauto_update;
 }
+
+MockedBrightnessModule::MockedBrightnessModule(QMainWindow *window) : BrightnessModule(true) { this->window = window; }
 
 void MockedBrightnessModule::set_brightness(int brightness) { this->window->setWindowOpacity(brightness / 255.0); }
 
-XBrightnessModule::XBrightnessModule(QMainWindow *window) : BrightnessModule(window)
+void RpiBrightnessModule::set_brightness(int brightness)
 {
-    this->screen = qApp->screens()[0];
+    QProcess process(this);
+    process.start(QString("echo %1 > /sys/class/backlight/rpi_backlight/brightness").arg(brightness));
+    process.waitForFinished();
+}
+
+XBrightnessModule::XBrightnessModule() : BrightnessModule(false)
+{
+    this->screen = QGuiApplication::primaryScreen();
 }
 
 void XBrightnessModule::set_brightness(int brightness)

--- a/src/app/modules/brightness.cpp
+++ b/src/app/modules/brightness.cpp
@@ -7,24 +7,11 @@
 
 BrightnessModule::BrightnessModule(QMainWindow *window) : QObject(qApp) { this->window = window; }
 
-int MockedBrightnessModule::get_brightness() { return this->window->windowOpacity() * 255; }
-
 void MockedBrightnessModule::set_brightness(int brightness) { this->window->setWindowOpacity(brightness / 255.0); }
 
 XBrightnessModule::XBrightnessModule(QMainWindow *window) : BrightnessModule(window)
 {
     this->screen = qApp->screens()[0];
-}
-
-int XBrightnessModule::get_brightness()
-{
-    QProcess process(this);
-    process.start("xrandr --current --verbose");
-    process.waitForFinished();
-    qDebug() << process.readAllStandardOutput();
-
-    return 255;
-
 }
 
 void XBrightnessModule::set_brightness(int brightness)

--- a/src/app/tabs/openauto.cpp
+++ b/src/app/tabs/openauto.cpp
@@ -147,14 +147,16 @@ OpenAutoTab::OpenAutoTab(QWidget *parent) : QWidget(parent)
         frame->setFocus();
     });
 
-    connect(window, &MainWindow::is_ready, [this, layout, frame, opacity = window->windowOpacity()]() {
+    connect(window, &MainWindow::is_ready, [this, layout, frame]() {
         frame->resize(this->size());
         auto callback = [frame](bool is_active) {
             frame->toggle(is_active);
             frame->setFocus();
         };
         if (this->worker == nullptr) this->worker = new OpenAutoWorker(callback, frame);
-        this->worker->set_opacity(opacity * 255);
+        BrightnessModule *module = this->config->get_brightness_module(this->config->get_brightness_module());
+        if (module->do_update_androidauto())
+            this->worker->set_opacity(this->config->get_brightness());
 
         layout->addWidget(this->msg_widget());
         layout->addWidget(frame);

--- a/src/app/tabs/openauto.cpp
+++ b/src/app/tabs/openauto.cpp
@@ -155,7 +155,7 @@ OpenAutoTab::OpenAutoTab(QWidget *parent) : QWidget(parent)
         };
         if (this->worker == nullptr) this->worker = new OpenAutoWorker(callback, frame);
         BrightnessModule *module = this->config->get_brightness_module(this->config->get_brightness_module());
-        if (module->do_update_androidauto())
+        if (module->update_androidauto())
             this->worker->set_opacity(this->config->get_brightness());
 
         layout->addWidget(this->msg_widget());

--- a/src/app/tabs/settings.cpp
+++ b/src/app/tabs/settings.cpp
@@ -49,6 +49,8 @@ QWidget *GeneralSettingsSubTab::settings_widget()
     layout->addWidget(this->si_units_row_widget(), 1);
     layout->addWidget(Theme::br(widget), 1);
     layout->addWidget(this->brightness_row_widget(), 1);
+    layout->addWidget(Theme::br(widget), 1);
+    layout->addWidget(this->quick_control_row_widget(), 1);
 
     QScrollArea *scroll_area = new QScrollArea(this);
     Theme::to_touch_scroller(scroll_area);
@@ -188,6 +190,62 @@ QWidget *GeneralSettingsSubTab::color_select_widget()
         label->update(color);
         this->theme->set_color(color);
         this->config->set_color(color);
+    });
+
+    layout->addStretch(1);
+    layout->addWidget(left_button);
+    layout->addWidget(label, 2);
+    layout->addWidget(right_button);
+    layout->addStretch(1);
+
+    return widget;
+}
+
+QWidget *GeneralSettingsSubTab::quick_control_row_widget()
+{
+    QWidget *widget = new QWidget(this);
+    QHBoxLayout *layout = new QHBoxLayout(widget);
+
+    QLabel *label = new QLabel("Quick Control", widget);
+    label->setFont(Theme::font_16);
+    layout->addWidget(label, 1);
+
+    layout->addWidget(this->quick_control_select_widget(), 1);
+
+    return widget;
+}
+
+QWidget *GeneralSettingsSubTab::quick_control_select_widget()
+{
+    QWidget *widget = new QWidget(this);
+    QHBoxLayout *layout = new QHBoxLayout(widget);
+
+    const QStringList controls = this->config->get_quick_controls().keys();
+
+    QLabel *label = new QLabel(this->config->get_quick_control(), widget);
+    label->setAlignment(Qt::AlignCenter);
+    label->setFont(Theme::font_16);
+
+    QPushButton *left_button = new QPushButton(widget);
+    left_button->setFlat(true);
+    left_button->setIconSize(Theme::icon_32);
+    this->theme->add_button_icon("arrow_left", left_button);
+    connect(left_button, &QPushButton::clicked, [this, label, controls]() {
+        int total_controls = controls.size();
+        QString control =
+            controls[((controls.indexOf(label->text()) - 1) % total_controls + total_controls) % total_controls];
+        label->setText(control);
+        this->config->set_quick_control(control);
+    });
+
+    QPushButton *right_button = new QPushButton(widget);
+    right_button->setFlat(true);
+    right_button->setIconSize(Theme::icon_32);
+    this->theme->add_button_icon("arrow_right", right_button);
+    connect(right_button, &QPushButton::clicked, [this, label, controls]() {
+        QString control = controls[(controls.indexOf(label->text()) + 1) % controls.size()];
+        label->setText(control);
+        this->config->set_quick_control(control);
     });
 
     layout->addStretch(1);

--- a/src/app/tabs/settings.cpp
+++ b/src/app/tabs/settings.cpp
@@ -51,7 +51,7 @@ QWidget *GeneralSettingsSubTab::settings_widget()
     layout->addWidget(this->brightness_module_row_widget(), 1);
     layout->addWidget(this->brightness_row_widget(), 1);
     layout->addWidget(Theme::br(widget), 1);
-    layout->addWidget(this->quick_control_row_widget(), 1);
+    layout->addWidget(this->quick_view_row_widget(), 1);
 
     QScrollArea *scroll_area = new QScrollArea(this);
     Theme::to_touch_scroller(scroll_area);
@@ -99,6 +99,40 @@ QWidget *GeneralSettingsSubTab::brightness_module_select_widget()
 {
     QWidget *widget = new QWidget(this);
     QHBoxLayout *layout = new QHBoxLayout(widget);
+
+    const QStringList modules = this->config->get_brightness_modules().keys();
+
+    QLabel *label = new QLabel(this->config->get_brightness_module(), widget);
+    label->setAlignment(Qt::AlignCenter);
+    label->setFont(Theme::font_16);
+
+    QPushButton *left_button = new QPushButton(widget);
+    left_button->setFlat(true);
+    left_button->setIconSize(Theme::icon_32);
+    this->theme->add_button_icon("arrow_left", left_button);
+    connect(left_button, &QPushButton::clicked, [this, label, modules]() {
+        int total_modules = modules.size();
+        QString module =
+            modules[((modules.indexOf(label->text()) - 1) % total_modules + total_modules) % total_modules];
+        label->setText(module);
+        this->config->set_brightness_module(module);
+    });
+
+    QPushButton *right_button = new QPushButton(widget);
+    right_button->setFlat(true);
+    right_button->setIconSize(Theme::icon_32);
+    this->theme->add_button_icon("arrow_right", right_button);
+    connect(right_button, &QPushButton::clicked, [this, label, modules]() {
+        QString module = modules[(modules.indexOf(label->text()) + 1) % modules.size()];
+        label->setText(module);
+        this->config->set_brightness_module(module);
+    });
+
+    layout->addStretch(1);
+    layout->addWidget(left_button);
+    layout->addWidget(label, 2);
+    layout->addWidget(right_button);
+    layout->addStretch(1);
 
     return widget;
 }
@@ -224,28 +258,28 @@ QWidget *GeneralSettingsSubTab::color_select_widget()
     return widget;
 }
 
-QWidget *GeneralSettingsSubTab::quick_control_row_widget()
+QWidget *GeneralSettingsSubTab::quick_view_row_widget()
 {
     QWidget *widget = new QWidget(this);
     QHBoxLayout *layout = new QHBoxLayout(widget);
 
-    QLabel *label = new QLabel("Quick Control", widget);
+    QLabel *label = new QLabel("Quick View", widget);
     label->setFont(Theme::font_16);
     layout->addWidget(label, 1);
 
-    layout->addWidget(this->quick_control_select_widget(), 1);
+    layout->addWidget(this->quick_view_select_widget(), 1);
 
     return widget;
 }
 
-QWidget *GeneralSettingsSubTab::quick_control_select_widget()
+QWidget *GeneralSettingsSubTab::quick_view_select_widget()
 {
     QWidget *widget = new QWidget(this);
     QHBoxLayout *layout = new QHBoxLayout(widget);
 
-    const QStringList controls = this->config->get_quick_controls().keys();
+    const QStringList views = this->config->get_quick_views().keys();
 
-    QLabel *label = new QLabel(this->config->get_quick_control(), widget);
+    QLabel *label = new QLabel(this->config->get_quick_view(), widget);
     label->setAlignment(Qt::AlignCenter);
     label->setFont(Theme::font_16);
 
@@ -253,22 +287,21 @@ QWidget *GeneralSettingsSubTab::quick_control_select_widget()
     left_button->setFlat(true);
     left_button->setIconSize(Theme::icon_32);
     this->theme->add_button_icon("arrow_left", left_button);
-    connect(left_button, &QPushButton::clicked, [this, label, controls]() {
-        int total_controls = controls.size();
-        QString control =
-            controls[((controls.indexOf(label->text()) - 1) % total_controls + total_controls) % total_controls];
-        label->setText(control);
-        this->config->set_quick_control(control);
+    connect(left_button, &QPushButton::clicked, [this, label, views]() {
+        int total_views = views.size();
+        QString view = views[((views.indexOf(label->text()) - 1) % total_views + total_views) % total_views];
+        label->setText(view);
+        this->config->set_quick_view(view);
     });
 
     QPushButton *right_button = new QPushButton(widget);
     right_button->setFlat(true);
     right_button->setIconSize(Theme::icon_32);
     this->theme->add_button_icon("arrow_right", right_button);
-    connect(right_button, &QPushButton::clicked, [this, label, controls]() {
-        QString control = controls[(controls.indexOf(label->text()) + 1) % controls.size()];
-        label->setText(control);
-        this->config->set_quick_control(control);
+    connect(right_button, &QPushButton::clicked, [this, label, views]() {
+        QString view = views[(views.indexOf(label->text()) + 1) % views.size()];
+        label->setText(view);
+        this->config->set_quick_view(view);
     });
 
     layout->addStretch(1);

--- a/src/app/tabs/settings.cpp
+++ b/src/app/tabs/settings.cpp
@@ -48,6 +48,7 @@ QWidget *GeneralSettingsSubTab::settings_widget()
     layout->addWidget(Theme::br(widget), 1);
     layout->addWidget(this->si_units_row_widget(), 1);
     layout->addWidget(Theme::br(widget), 1);
+    layout->addWidget(this->brightness_module_row_widget(), 1);
     layout->addWidget(this->brightness_row_widget(), 1);
     layout->addWidget(Theme::br(widget), 1);
     layout->addWidget(this->quick_control_row_widget(), 1);
@@ -76,6 +77,28 @@ QWidget *GeneralSettingsSubTab::dark_mode_row_widget()
         config->set_dark_mode(state);
     });
     layout->addWidget(toggle, 1, Qt::AlignHCenter);
+
+    return widget;
+}
+
+QWidget *GeneralSettingsSubTab::brightness_module_row_widget()
+{
+    QWidget *widget = new QWidget(this);
+    QHBoxLayout *layout = new QHBoxLayout(widget);
+
+    QLabel *label = new QLabel("Brightness Module", widget);
+    label->setFont(Theme::font_16);
+    layout->addWidget(label, 1);
+
+    layout->addWidget(this->brightness_module_select_widget(), 1);
+
+    return widget;
+}
+
+QWidget *GeneralSettingsSubTab::brightness_module_select_widget()
+{
+    QWidget *widget = new QWidget(this);
+    QHBoxLayout *layout = new QHBoxLayout(widget);
 
     return widget;
 }

--- a/src/app/widgets/color_label.cpp
+++ b/src/app/widgets/color_label.cpp
@@ -10,17 +10,17 @@ ColorLabel::ColorLabel(QSize block_size, QWidget *parent) : QWidget(parent)
 {
     this->theme = Theme::get_instance();
 
-    QString default_color = Config::get_instance()->get_color();
+    QString color = Config::get_instance()->get_color();
 
     QHBoxLayout *layout = new QHBoxLayout(this);
 
     this->icon = new QLabel(this);
     QPixmap block(block_size);
-    block.fill(this->theme->get_color(default_color));
+    block.fill(this->theme->get_color(color));
     this->icon->setPixmap(block);
 
     this->name = new QLabel(this);
-    this->name->setText(default_color);
+    this->name->setText(color);
 
     connect(this->theme, &Theme::color_updated, [this]() { this->update(this->text()); });
 

--- a/src/app/window.cpp
+++ b/src/app/window.cpp
@@ -19,11 +19,12 @@ MainWindow::MainWindow()
     this->theme->set_mode(this->config->get_dark_mode());
     this->theme->set_color(this->config->get_color());
 
-    this->config->add_quick_view("none", new QFrame(this));
     this->config->add_quick_view("volume", this->volume_widget());
+    this->config->add_quick_view("none", new QFrame(this));
 
     this->config->add_brightness_module("mocked", new MockedBrightnessModule(this));
-    this->config->add_brightness_module("x", new XBrightnessModule(this));
+    this->config->add_brightness_module("x", new XBrightnessModule());
+    this->config->add_brightness_module("rpi 7\"", new RpiBrightnessModule());
 
     BrightnessModule *module = this->config->get_brightness_module(this->config->get_brightness_module());
     module->set_brightness(this->config->get_brightness());

--- a/src/app/window.cpp
+++ b/src/app/window.cpp
@@ -70,7 +70,7 @@ QTabWidget *MainWindow::tabs_widget()
     connect(this->config, &Config::brightness_changed, [this, widget](int position) {
         BrightnessModule *module = this->config->get_brightness_module(this->config->get_brightness_module());
         module->set_brightness(position);
-        if (widget->currentIndex() == 0 && module->do_update_androidauto()) emit set_openauto_state(position);
+        if (widget->currentIndex() == 0 && module->update_androidauto()) emit set_openauto_state(position);
     });
     connect(this->theme, &Theme::icons_updated,
             [widget](QList<tab_icon_t> &tab_icons, QList<button_icon_t> &button_icons) {
@@ -79,7 +79,7 @@ QTabWidget *MainWindow::tabs_widget()
             });
     connect(widget, &QTabWidget::currentChanged, [this](int index) {
         BrightnessModule *module = this->config->get_brightness_module(this->config->get_brightness_module());
-        int alpha = module->do_update_androidauto() ? this->config->get_brightness() : 255;
+        int alpha = module->update_androidauto() ? this->config->get_brightness() : 255;
         emit set_openauto_state((index == 0) ? alpha : 0);
     });
 

--- a/src/app/window.cpp
+++ b/src/app/window.cpp
@@ -19,6 +19,8 @@ MainWindow::MainWindow()
     this->theme->set_mode(this->config->get_dark_mode());
     this->theme->set_color(this->config->get_color());
 
+    this->config->add_quick_control("volume", this->volume_widget());
+
     QFrame *widget = new QFrame(this);
     this->layout = new QStackedLayout(widget);
 
@@ -109,12 +111,31 @@ QWidget *MainWindow::controls_widget()
         if (system(cmd.str().c_str()) < 0) qApp->exit();
     });
 
+    QWidget *quick_control = this->quick_control_widget();
+    quick_control->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+
     layout->addWidget(tab_spacer);
-    layout->addWidget(this->volume_widget());
+    layout->addWidget(quick_control);
     layout->addStretch();
     layout->addWidget(save_button);
     layout->addWidget(shutdown_button);
     layout->addWidget(exit_button);
+
+    return widget;
+}
+
+QWidget *MainWindow::quick_control_widget()
+{
+    QWidget *widget = new QWidget(this);
+    QStackedLayout *layout = new QStackedLayout(widget);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    QMap<QString, QWidget *> quick_controls = this->config->get_quick_controls();
+    for (auto quick_control : quick_controls.values()) layout->addWidget(quick_control);
+    layout->setCurrentWidget(quick_controls[this->config->get_quick_control()]);
+    connect(this->config, &Config::quick_control_changed, [layout, quick_controls](QString quick_control) {
+        layout->setCurrentWidget(quick_controls[quick_control]);
+    });
 
     return widget;
 }


### PR DESCRIPTION
Laying the framework for supporting custom modules. The first two being the quick view (where for the time being will either be the volume slider or none) and the brightness slider.

In the future, I have hopes that modules can be dynamically added at runtime, where users can keep a library of whatever they need for their setup so ia can be suited for their needs. This will be especially helpful for the data tab where different cars might have different CAN interfaces and thus would need to be designed per user (or at least per car manufacturer lol).

For the x brightness module, I will also want to come back to it and use xlib to control the brightness instead of calling a command to do it. It would also probs be a good idea to extend the brightness modules to support "watching" the brightness so ia can adjust if brightness is changed externally.