### PR TITLE
Suppress libusb compile warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,6 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}
                     ${Qt5Widgets_INCLUDE_DIRS}
                     ${Qt5Bluetooth_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIRS}
-                    ${LIBUSB_1_INCLUDE_DIRS}
                     ${PROTOBUF_INCLUDE_DIR}
                     ${OPENSSL_INCLUDE_DIR}
                     ${RTAUDIO_INCLUDE_DIRS}
@@ -69,6 +68,8 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}
                     ${TAGLIB_INCLUDE_DIRS}
                     ${X11_INCLUDE_DIR}
                     ${include_directory})
+
+include_directories(SYSTEM ${LIBUSB_1_INCLUDE_DIRS})
 
 link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 


### PR DESCRIPTION
This same change can also be done for subprojects aasdk/ and openauto/ though I'm not sure the correct protocol for doing that.